### PR TITLE
Updated foresight link and desc

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -107,7 +107,7 @@ If we are missing some awesome testing tool that you already know, follow our [c
 
 | Name | Description | Link | Price |
 |---|---|---|--|
-| Thundra Foresight | Thundra Foresight is a CI observability tool that provides visibility into your test suites. | https://www.thundra.io/foresight | Free |
+| Foresight | GitHub Actions and test monitoring tool. Foresight provides full visibility and deep insights into the health and performance of your tests and CI/CD pipelines. Monitor GitHub Actions CI workflows, tests, builds, steps, and more with Foresight. | https://www.runforesight.com | Free for open-source |
 | Datadog | Datadog is a monitoring, security and analytics platform for developers, IT operations teams, security engineers and business users in the cloud age. Datadog's SaaS platform integrates and automates infrastructure monitoring, application performance monitoring and log management to provide unified, real-time observability of their customers' entire technology stack. Datadog is used by organizations of all sizes and across a wide range of industries to enable digital transformation and cloud migration, drive collaboration among development, operations, security and business teams, accelerate time to market for applications, reduce time to problem resolution, secure applications and infrastructure, understand user behavior and track key business metrics.| https://www.datadoghq.com/ | Paid |
 
 ## Contract Testing tools


### PR DESCRIPTION
Hey there, we have changed the URL for Foresight. Now, it is a standalone product. I've updated the link and description accordingly. 