### PR TITLE
Add Multiplayer to "Test Observability Tools"

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -114,6 +114,7 @@
 
 - [Datadog](https://www.datadoghq.com/) - Monitoring, security and analytics platform for developers, IT operations teams, security engineers and business users in the cloud age. Datadog's SaaS platform integrates and automates infrastructure monitoring, application performance monitoring and log management to provide unified, real-time observability of their customers' entire technology stack. Datadog is used by organizations of all sizes and across a wide range of industries to enable digital transformation and cloud migration, drive collaboration among development, operations, security and business teams, accelerate time to market for applications, reduce time to problem resolution, secure applications and infrastructure, understand user behavior and track key business metrics.
 - [TestDino](https://testdino.com/) - Test observability platform that centralizes runs, errors, and coverage trends into one analytics dashboard, with flaky-test tracking, AI failure insights, and CI-aware views that cut debugging time, reduce flaky failures, and lower CI costs for growing automation suites.
+- [Multiplayer](https://multiplayer.app/) - Open-source debugging agent that runs locally next to coding agents like Claude Code, Codex, and Copilot, capturing full-stack, unsampled runtime session data to catch and fix bugs automatically.
 
 ## Accessibility Testing Tools
 


### PR DESCRIPTION
Adding Multiplayer to Test Observability Tools. It's an open-source debugging agent that connects coding agents (Claude Code, Codex, Copilot) to runtime session data. It's focused on feeding coding agents the exact data (full-stack, unsampled, session-based) they need to fix bugs automatically, including data other observability tools miss such as request/response content and headers from all components in your system.

Website: https://www.multiplayer.app/
Github repo: https://github.com/multiplayer-app/multiplayer