### PR TITLE
Add tapflow under Mobile Testing Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -95,6 +95,7 @@
 - [React Native Testing Library](https://callstack.github.io/react-native-testing-library/) - The React Native Testing Library is a lightweight solution for testing React Native components. It provides light utility functions on top of react-test-renderer, in a way that encourages better testing practices.
 - [Robolectric](http://robolectric.org/) - Open source test framework for Android. It provides faster unit-testing by running tests inside JVM.
 - [Sherlo](https://github.com/sherlo-io/sherlo) - Visual testing platform for React Native Storybook. It captures screenshots on iOS and Android simulators in the cloud and detects visual changes automatically.
+- [tapflow](https://github.com/jo-duchan/tapflow) - Self-hosted mobile QA tool that streams iOS simulators and Android emulators to the browser for team-wide testing without local setup.
 
 ## Penetration Testing Tools
 


### PR DESCRIPTION
Adds [tapflow](https://github.com/jo-duchan/tapflow) to the **Mobile Testing Tools** section.

tapflow is an open-source, self-hosted tool that streams iOS simulators and Android emulators to the browser, letting the whole team (PM, designers, QA, engineers) test native mobile builds without any local Xcode/SDK setup.

- [x] Searched for duplicates — not currently listed
- [x] Individual PR for a single suggestion
- [x] Placed under the corresponding section (Mobile Testing Tools)
- [x] Checked spelling and grammar