### PR TITLE
Add FlakeTrack to Test Observability Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -114,6 +114,7 @@
 
 - [Datadog](https://www.datadoghq.com/) - Monitoring, security and analytics platform for developers, IT operations teams, security engineers and business users in the cloud age. Datadog's SaaS platform integrates and automates infrastructure monitoring, application performance monitoring and log management to provide unified, real-time observability of their customers' entire technology stack. Datadog is used by organizations of all sizes and across a wide range of industries to enable digital transformation and cloud migration, drive collaboration among development, operations, security and business teams, accelerate time to market for applications, reduce time to problem resolution, secure applications and infrastructure, understand user behavior and track key business metrics.
 - [TestDino](https://testdino.com/) - Test observability platform that centralizes runs, errors, and coverage trends into one analytics dashboard, with flaky-test tracking, AI failure insights, and CI-aware views that cut debugging time, reduce flaky failures, and lower CI costs for growing automation suites.
+- [FlakeTrack](https://github.com/cbrown350/flaketrack) - GitHub Action that detects, trends, and quarantines flaky JUnit tests using only resources you already control: it ingests JUnit XML after your test step and stores the full history in your own repo (a branch, Issues, and a static GitHub Pages dashboard), with no external account, server, or hosted database.
 
 ## Accessibility Testing Tools
 


### PR DESCRIPTION
Adds FlakeTrack to the Test Observability Tools section, alongside Datadog and TestDino.

FlakeTrack is a GitHub Action for flaky-test detection/trending/quarantine that stores all history in the user's own repo (branch + Issues + GitHub Pages dashboard) rather than a third-party hosted platform — no external account, server, or database required.

- Repo: https://github.com/cbrown350/flaketrack
- One suggestion per PR, per contributing.md.