### PR TITLE
Add Qualflare to Test Observability Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -113,6 +113,7 @@
 ## Test Observability Tools
 
 - [Datadog](https://www.datadoghq.com/) - Monitoring, security and analytics platform for developers, IT operations teams, security engineers and business users in the cloud age. Datadog's SaaS platform integrates and automates infrastructure monitoring, application performance monitoring and log management to provide unified, real-time observability of their customers' entire technology stack. Datadog is used by organizations of all sizes and across a wide range of industries to enable digital transformation and cloud migration, drive collaboration among development, operations, security and business teams, accelerate time to market for applications, reduce time to problem resolution, secure applications and infrastructure, understand user behavior and track key business metrics.
+- [Qualflare](https://qualflare.com/test-observability/) - AI test management and observability platform that turns CI results into answers: history-based flaky-test detection, failure clustering by root cause, reliability trends, and release-risk scoring across 23 frameworks.
 - [TestDino](https://testdino.com/) - Test observability platform that centralizes runs, errors, and coverage trends into one analytics dashboard, with flaky-test tracking, AI failure insights, and CI-aware views that cut debugging time, reduce flaky failures, and lower CI costs for growing automation suites.
 
 ## Accessibility Testing Tools


### PR DESCRIPTION
Adds [Qualflare](https://qualflare.com/test-observability/) to **Test Observability Tools**.

Qualflare is my SaaS — an AI test management & observability platform: it ingests CI results and provides history-based flaky-test detection, failure clustering by root cause, reliability trends, and release-risk scoring across 23 frameworks. It sits in the same category as the existing entries (TestDino, Datadog).

Entry is placed alphabetically and matches the section's format. Happy to tweak the wording.
