### PR TITLE
Add QAPractices to automated testing tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -71,6 +71,7 @@
 - [Wopee.io](https://wopee.io/) - Autonomous testing platform that uses visual AI to automatically validate web applications. It integrates with Playwright, Cypress, and other frameworks to provide visual regression testing, autonomous test maintenance, and AI-powered test result analysis.
 - [Zato API Test](https://zato.io/) - API testing in pure English. No programming needed. Implemented and extendable in Python.
 - [Zyntra](https://zyntra.app/) - Unlimited e-mail inboxes with API/UI access. Catch OTPs, reset links, and sign-up emails in your test flows.
+- [QAPractices](https://qapractices.com/) - Curated QA platform with free test cases, checklists, templates, AI prompts and guides for API, web, mobile, security, accessibility and performance testing.
 
 ## Load Testing Tools
 


### PR DESCRIPTION
I've been using QAPractices as a go-to place for test cases, checklists and templates when setting up automation suites. It's a free, curated platform that covers API, web, mobile, security, accessibility and performance testing.

I think it fits the automated testing tools section as a practical resource alongside the automation frameworks listed there.