### PR TITLE
Add ReproProof to test observability tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -114,6 +114,7 @@
 
 - [Datadog](https://www.datadoghq.com/) - Monitoring, security and analytics platform for developers, IT operations teams, security engineers and business users in the cloud age. Datadog's SaaS platform integrates and automates infrastructure monitoring, application performance monitoring and log management to provide unified, real-time observability of their customers' entire technology stack. Datadog is used by organizations of all sizes and across a wide range of industries to enable digital transformation and cloud migration, drive collaboration among development, operations, security and business teams, accelerate time to market for applications, reduce time to problem resolution, secure applications and infrastructure, understand user behavior and track key business metrics.
 - [TestDino](https://testdino.com/) - Test observability platform that centralizes runs, errors, and coverage trends into one analytics dashboard, with flaky-test tracking, AI failure insights, and CI-aware views that cut debugging time, reduce flaky failures, and lower CI costs for growing automation suites.
+- [ReproProof](https://github.com/shleder/reproproof) - Redacted, verifiable reproducibility receipts for Node.js, Bun, Python and uv bug reports, capturing runtime, dependency and Git context for CI and maintenance debugging.
 
 ## Accessibility Testing Tools
 


### PR DESCRIPTION
Adds one entry under Test Observability Tools. ReproProof provides redacted, verifiable reproducibility receipts for Node.js, Bun, Python and uv bug reports, capturing runtime, dependency and Git context for CI and maintenance debugging. This is one standalone suggestion, with no changes outside readme.md.