### PR TITLE
Add a11y-matrix to Accessibility Testing Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -119,6 +119,7 @@
 
 Accessibility testing ensures that web applications and websites are usable by people with disabilities, in compliance with standards like WCAG 2.1/2.2 and regulations such as ADA, Section 508, and the European Accessibility Act.
 
+- [a11y-matrix](https://github.com/henriqueyuri00/a11y-matrix) - Runs axe-core across the browser states a single CI run never enters: dark mode, reduced motion, forced colors, mobile, and the 320px reflow width WCAG 1.4.10 requires. Reports only the findings present in one state and absent from the baseline, so each is attributed to the preference that exposed it. CLI and GitHub Action, MIT.
 - [axe DevTools](https://www.deque.com/axe/devtools/) - Industry-standard accessibility testing toolkit by Deque. Browser extension and CLI that checks against WCAG 2.2 standards. Powers accessibility testing in many CI/CD pipelines.
 - [axe-core](https://github.com/dequelabs/axe-core) - An open-source accessibility testing engine for automated web UI testing. Created by Deque Systems, it powers many other accessibility tools and integrates with Selenium, Playwright, Cypress, and more.
 - [Lighthouse](https://developer.chrome.com/docs/lighthouse) - An open-source automated tool by Google for improving the quality of web pages. Includes accessibility audits powered by axe-core alongside performance, SEO, and best practices checks. Built into Chrome DevTools.


### PR DESCRIPTION
Adds [a11y-matrix](https://github.com/henriqueyuri00/a11y-matrix) to **Accessibility Testing Tools**.

**Disclosure: I built this.** Completely fine to close if self-submissions aren't welcome.

- [x] Added to an existing section, alphabetically (before *axe DevTools*)
- [x] Matches the surrounding entry format: `- [Name](url) - Description.`
- [x] Checked the existing list and the open pull requests — not a duplicate
- [x] One line added, nothing else touched, no trailing whitespace

### What it does that the tools already listed do not

axe-core, Pa11y and Lighthouse all evaluate the page in whatever state the browser is currently rendering. In CI that is always the same one: light colour scheme, no motion preference, forced colors off, desktop viewport.

a11y-matrix loads the page once per user-preference state and reports only the findings that exist in one state and **not** in the baseline — so each is attributed to the preference that exposed it, rather than added to an anonymous count.

Two details that are load-bearing:

- It collects axe's `incomplete` results as well as `violations`, kept clearly separate. Text at exactly 1:1 contrast against its own background — invisible — is reported by axe as `incomplete`, not a violation, because it cannot prove the element was not deliberately hidden. Pipelines that assert on `violations` discard it.
- It measures WCAG 1.4.10 reflow directly (document `scrollWidth` against viewport width) rather than inferring it, since axe has no rule for 1.4.10.

### Evidence it finds real things

I ran it against 36 public homepages — W3C, MDN, React, Kubernetes, GitHub, Wikipedia, GOV.UK, the BBC, several design systems.

**24 of 34 stable sites (71%) had at least one finding the baseline run never surfaced; 16 of 34 (47%) had a violation rather than something needing review.** Median two per site. Six were clean in all seven states: W3C, WebAIM, MDN, Playwright, Primer, GOV.UK.

There is a control run: the same state twice, nothing changed, produced 7 spurious findings across all 36 sites, so the signal clears the noise by roughly forty to one. The two unstable sites are excluded from that figure rather than left in the denominator.

[Method, counting rules, caveats and raw per-site data](https://github.com/henriqueyuri00/a11y-matrix/tree/main/study) are all committed, so the interpretation can be argued with without re-running anything.

Runs with `npx github:henriqueyuri00/a11y-matrix <url>`. CI exercises the composite action for real: a deliberately broken fixture must fail the build and a clean one must not.